### PR TITLE
Change base folder path to user's joinedTeams instead of Sites

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,7 @@ Metrics/ClassLength:
   Max: 130
   Exclude:
     - 'lib/browse_everything/driver/google_drive.rb'
+    - 'lib/browse_everything/driver/sharepoint.rb'
 
 Metrics/MethodLength:
   Exclude:
@@ -79,6 +80,7 @@ Style/MixinUsage:
     - 'spec/lib/browse_everything/driver/file_system_spec.rb'
     - 'spec/lib/browse_everything/driver/google_drive_spec.rb'
     - 'spec/lib/browse_everything/driver/s3_spec.rb'
+    - 'spec/lib/browse_everything/driver/sharepoint_spec.rb'
     - 'spec/services/browser_factory_spec.rb'
 
 Style/NumericLiterals:

--- a/SharePoint.md
+++ b/SharePoint.md
@@ -13,10 +13,10 @@ Prerequisite:
     * offline_access
     * openid
     * profile
-    * Sites.Read.All
+    * Team.ReadBasic.All
     * User.Read
 
-To use the sharepoint provider add the following to `config/browse_everything_providers.yml`. The `filter_terms` parameter is optional. Commenting it out will return all sites that a user has access to. If an array of terms is provided the list of sites will be filtered so that only sites containing any of the terms are returned.
+To use the sharepoint provider add the following to `config/browse_everything_providers.yml`:
 
 ```
 sharepoint:
@@ -25,5 +25,4 @@ sharepoint:
   tenant_id: MyAzureTenantID
   redirect_uri: https://avalon_example.com/browse/connect
   scope: offline_access https://graph.microsoft.com/.default
-  filter_terms: ['filter', 'terms']
 ```

--- a/lib/browse_everything/auth/sharepoint/session.rb
+++ b/lib/browse_everything/auth/sharepoint/session.rb
@@ -114,13 +114,14 @@ module BrowseEverything
           open(url, params)
         end
 
+        # rubocop: disable Metrics/CyclomaticComplexity
         def handle_errors(response, raw)
           status = response.code.to_i
           body = response.body
           begin
             parsed_body = JSON.parse(body)
           rescue
-            msg = body.blank? ? "no data returned" : body
+            msg = body.presence || "no data returned"
             parsed_body = { "message" => msg }
           end
 
@@ -141,6 +142,7 @@ module BrowseEverything
           end
           raw ? body : parsed_body
         end
+        # rubocop: enable Metrics/CyclomaticComplexity
       end
     end
   end

--- a/lib/browse_everything/driver/sharepoint.rb
+++ b/lib/browse_everything/driver/sharepoint.rb
@@ -97,7 +97,7 @@ module BrowseEverything
         base.each do |k, v|
           query += ["#{k}=#{v}"]
         end
-        query += ["response_type=code"]
+        query += ["response_type=code", @consent_refresh.present? ? "prompt=consent" : nil].compact
 
         query.join('&')
       end
@@ -169,7 +169,11 @@ module BrowseEverything
           request = Net::HTTP::Get.new(uri.request_uri, { 'Authorization' => @auth })
           http.request(request)
         end
-        JSON.parse(response.body)
+
+        parsed_response = JSON.parse(response.body)
+        @consent_refresh = parsed_response.dig('error', 'message')&.include?('Missing scope permissions on the request.') ? true : false
+
+        parsed_response
       end
 
       # Constructs a BrowseEverything::FileEntry object for a Sharepoint file

--- a/lib/browse_everything/driver/sharepoint.rb
+++ b/lib/browse_everything/driver/sharepoint.rb
@@ -42,7 +42,9 @@ module BrowseEverything
 
         folder = []
         if id.empty?
-          folder << sites
+          # The metadata returned does not have anything identifiable as results being teams.
+          # To facilitate getting subsequent routes correct we add a teams identifier.
+          folder << teams.map { |t| t.merge!({ teams: true }) }
           folder << drives
         else
           folder << items_by_id(id)
@@ -51,6 +53,9 @@ module BrowseEverything
         values = []
 
         folder.flatten.each do |f|
+          # Entries in folder array should not have a value key.
+          # Skip entries that do to prevent blank folders in list.
+          next if f['value']
           values << directory_entry(f)
         end
         @entries = values.compact
@@ -150,7 +155,9 @@ module BrowseEverything
       def expiration_time
         return unless @token
         expires_at = @token.fetch('expires_at', nil)
+        # rubocop: disable Style/SafeNavigation
         expires_at.nil? ? nil : expires_at.to_i
+        # rubocop: enable Style/SafeNavigation
       end
 
       def token_expired?
@@ -171,6 +178,8 @@ module BrowseEverything
         end
 
         parsed_response = JSON.parse(response.body)
+        # If permissions are changed, we need to redirect the user to the consent
+        # page so they can agree to the new permissions. Set flag for that here.
         @consent_refresh = parsed_response.dig('error', 'message')&.include?('Missing scope permissions on the request.') ? true : false
 
         parsed_response
@@ -185,7 +194,7 @@ module BrowseEverything
                                         [key, make_path(file)].join(':'),
                                         file['displayName'] ? file['displayName'] : file['name'],
                                         file['size'] ? file['size'] : nil,
-                                        Date.parse(file['lastModifiedDateTime']),
+                                        file['lastModifiedDateTime'] ? Date.parse(file['lastModifiedDateTime']) : nil,
                                         folder?(file))
       end
 
@@ -194,7 +203,7 @@ module BrowseEverything
       def make_path(file)
         if file['parentReference'].present?
           folder?(file) ? "#{file['parentReference']['driveId']}/items/#{file['id']}/children" : "#{file['parentReference']['driveId']}/items/#{file['id']}"
-        elsif file['id'].include?(root_site)
+        elsif file[:teams].present?
           "#{file['id']}/drives"
         else
           "#{file['id']}/root/children"
@@ -205,22 +214,26 @@ module BrowseEverything
         file['file'].blank?
       end
 
-      def root_site
-        @root_site ||= sharepoint_request("https://graph.microsoft.com/v1.0/sites/root?select=siteCollection")['siteCollection']['hostname']
-      end
+      # def root_site
+      #   @root_site ||= sharepoint_request("https://graph.microsoft.com/v1.0/sites/root?select=siteCollection")['siteCollection']['hostname']
+      # end
 
-      def sites
-        filter = config[:filter_terms]&.join(' OR ')
-        @sites ||= sharepoint_request("https://graph.microsoft.com/v1.0/sites?$select=id,displayName,name,lastModifiedDateTime&search=#{filter}")['value']
+      # def sites
+      #   filter = config[:filter_terms]&.join(' OR ')
+      #   @sites ||= sharepoint_request("https://graph.microsoft.com/v1.0/sites?$select=id,displayName,name,lastModifiedDateTime&search=#{filter}")['value']
+      # end
+
+      def teams
+        @teams ||= sharepoint_request("https://graph.microsoft.com/v1.0/me/joinedTeams?$select=id,displayName")['value']
       end
 
       def drives
-        @drives = sharepoint_request("https://graph.microsoft.com/v1.0/me/drives?$select=id,name,lastModifiedDateTime")['value']
+        @drives ||= sharepoint_request("https://graph.microsoft.com/v1.0/me/drives?$select=id,name,lastModifiedDateTime")['value']
       end
 
       def items_by_id(id)
-        item = if id.include?(root_site)
-                 sharepoint_request("https://graph.microsoft.com/v1.0/sites/#{id}")
+        item = if id.end_with?('drives')
+                 sharepoint_request("https://graph.microsoft.com/v1.0/groups/#{id}")
                else
                  sharepoint_request("https://graph.microsoft.com/v1.0/me/drives/#{id}")
                end

--- a/spec/lib/browse_everything/driver/sharepoint_spec.rb
+++ b/spec/lib/browse_everything/driver/sharepoint_spec.rb
@@ -97,13 +97,12 @@ describe BrowseEverything::Driver::Sharepoint do
     end
 
     describe '#contents' do
-      let(:site) do
+      let(:team) do
         {
           'value': [
             {
-              'id': 'site-id1',
-              'displayName': 'Site',
-              'lastModifiedDateTime': Time.current
+              'id': 'team-id1',
+              'displayName': 'Team'
             }
           ]
         }.to_json
@@ -122,9 +121,9 @@ describe BrowseEverything::Driver::Sharepoint do
 
       before do
         stub_request(
-          :get, "https://graph.microsoft.com/v1.0/sites?$select=id,displayName,name,lastModifiedDateTime&search="
+          :get, "https://graph.microsoft.com/v1.0/me/joinedTeams?$select=id,displayName"
         ).to_return(
-          body: site,
+          body: team,
           status: 200,
           headers: {}
         )
@@ -145,9 +144,9 @@ describe BrowseEverything::Driver::Sharepoint do
           expect(contents).not_to be_empty
 
           expect(contents.first).to be_a BrowseEverything::FileEntry
-          expect(contents.first.location).to eq 'sharepoint:site-id1/drives'
-          expect(contents.first.mtime).to be_a Date
-          expect(contents.first.name).to eq 'Site'
+          expect(contents.first.location).to eq 'sharepoint:team-id1/drives'
+          expect(contents.first.mtime).to eq nil
+          expect(contents.first.name).to eq 'Team'
           expect(contents.first.size).to eq nil
           expect(contents.first.type).to eq 'application/x-directory'
 
@@ -253,7 +252,16 @@ describe BrowseEverything::Driver::Sharepoint do
 
       it 'exposes the authorization endpoint URI' do
         expect(uri).to be_a Addressable::URI
-        expect(uri.to_s).to eq 'https://login.microsoftonline.com/TENANTID/oauth2/v2.0/authorize?client_id=CLIENTID&scope=offline_access https://graph.microsoft.com/.default&redirect_uri=http://example.com/browse/connect&response_type=code'
+        expect(uri.normalize.to_s).to eq 'https://login.microsoftonline.com/TENANTID/oauth2/v2.0/authorize?client_id=CLIENTID&scope=offline_access%20https://graph.microsoft.com/.default&redirect_uri=http://example.com/browse/connect&response_type=code'
+      end
+
+      context 'when permissions have changed' do
+        before { driver.instance_variable_set(:@consent_refresh, 'true') }
+
+        it 'includes "prompt=consent" in the auth_link' do
+          expect(uri).to be_a Addressable::URI
+          expect(uri.normalize.to_s).to eq 'https://login.microsoftonline.com/TENANTID/oauth2/v2.0/authorize?client_id=CLIENTID&scope=offline_access%20https://graph.microsoft.com/.default&redirect_uri=http://example.com/browse/connect&response_type=code&prompt=consent'
+        end
       end
     end
   end


### PR DESCRIPTION
The sites endpoint returns every single sharepoint site that a user has access to. This list can include many more options than a user would expect, including stuff that the user should technically not have access to (such as if a site has its permissions misconfigured). While we can use a $search param to narrow the results, we can only get so granular and so even the filtered results may provide an unwieldy amount of folders.

Because IU is interested in uploading files that are stored on sharepoint drives that originate from Microsoft Teams, we can use the `joinedTeams` endpoint to only return drives that a user is explicitly a member of. This creates a much more sensible and manageable list for users to browse through and one that should have no surprises for the user.

This PR also includes a change to the auth flow so that if required permissions are changed in the Entra admin center, the application will have users re-consent to permissions.